### PR TITLE
fix: handle unescaped List<?> datatype

### DIFF
--- a/bricks/dart/model/__brick__/{{name}}.dart
+++ b/bricks/dart/model/__brick__/{{name}}.dart
@@ -1,5 +1,5 @@
 class {{name.pascalCase()}} { {{#properties_types}}
-  final {{.}};{{/properties_types}}
+  final {{{ . }}};{{/properties_types}}
 
   {{name.pascalCase()}}({{#properties}}
     this.{{.}},{{/properties}}


### PR DESCRIPTION
https://github.com/supagen/supagen/issues/12

fix on model where it now can handle dataype of  any form of List<>